### PR TITLE
Implement undo history, reveal controls, and post-game summary

### DIFF
--- a/Sources/SpiteAndMaliceApp/SpiteAndMaliceApp.swift
+++ b/Sources/SpiteAndMaliceApp/SpiteAndMaliceApp.swift
@@ -10,7 +10,8 @@ struct SpiteAndMaliceApp: App {
             ContentView()
                 .environmentObject(viewModel)
         }
-        .windowResizability(.contentSize)
+        .windowResizability(.automatic)
+        .defaultSize(width: 1440, height: 900)
         .commands {
             CommandGroup(replacing: .newItem) {
                 Button("New Game") {
@@ -20,6 +21,12 @@ struct SpiteAndMaliceApp: App {
             }
 
             CommandMenu("Gameplay") {
+                Button("Undo Move") {
+                    viewModel.undoLastAction()
+                }
+                .keyboardShortcut("z", modifiers: [.command])
+                .disabled(!viewModel.canUndoTurn)
+
                 Button("Hint") {
                     viewModel.provideHint()
                 }

--- a/Sources/SpiteAndMaliceApp/Views/CardStackRevealView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/CardStackRevealView.swift
@@ -1,0 +1,53 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import SpiteAndMaliceCore
+
+struct CardStackRevealView: View {
+    var cards: [Card]
+    var isFaceDown: Bool = false
+
+    private let cardScale: CGFloat = 0.92
+    private let cardSpacing: CGFloat = 12
+
+    private var orderedCards: [Card] { Array(cards.reversed()) }
+
+    private var contentHeight: CGFloat {
+        let cardHeight = 98 * cardScale
+        let spacing = max(0, CGFloat(orderedCards.count - 1)) * cardSpacing
+        return CGFloat(orderedCards.count) * cardHeight + spacing + 16
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: orderedCards.count > 4) {
+            VStack(spacing: cardSpacing) {
+                ForEach(orderedCards) { card in
+                    CardView(
+                        card: card,
+                        isFaceDown: isFaceDown && card.id != orderedCards.first?.id,
+                        scale: cardScale
+                    )
+                    .transition(
+                        .move(edge: .bottom)
+                            .combined(with: .opacity)
+                    )
+                }
+            }
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+        }
+        .frame(
+            width: 110,
+            height: min(max(contentHeight, 160), 320)
+        )
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.black.opacity(0.45))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .stroke(Color.white.opacity(0.25), lineWidth: 1.5)
+        )
+        .shadow(color: Color.black.opacity(0.35), radius: 14, x: 0, y: 10)
+    }
+}
+#endif

--- a/Sources/SpiteAndMaliceApp/Views/ContentView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ContentView.swift
@@ -2,33 +2,60 @@
 import SwiftUI
 import SpiteAndMaliceCore
 
+private struct DiscardIdentifier: Hashable {
+    let playerID: UUID
+    let pileIndex: Int
+}
+
 struct ContentView: View {
     @EnvironmentObject private var viewModel: GameViewModel
+    @State private var revealedBuildPileIDs: Set<UUID> = []
+    @State private var revealedStockPlayerIDs: Set<UUID> = []
+    @State private var revealedDiscardIdentifiers: Set<DiscardIdentifier> = []
 
     var body: some View {
+        let summary = viewModel.gameSummary
         ZStack(alignment: .top) {
             backgroundView
-            VStack(alignment: .leading, spacing: 24) {
-                header
-                opponentsSection
-                centrePlayArea
-                humanSection
-                controlSection
-                footerSection
-            }
-            .padding(24)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            mainContent
+                .blur(radius: summary == nil ? 0 : 8)
+                .allowsHitTesting(summary == nil)
 
-            if let hint = viewModel.hint?.message {
+            if let hint = viewModel.hint?.message, summary == nil {
                 VStack {
                     HintOverlayView(message: hint)
                     Spacer()
                 }
-                .padding(.top, 16)
+                .padding(.top, 24)
                 .transition(.opacity)
             }
+
+            if let summary {
+                WinOverlayView(summary: summary, onPlayAgain: viewModel.startNewGame)
+                    .padding(.horizontal, 32)
+                    .transition(.opacity.combined(with: .scale))
+            }
         }
-        .frame(minWidth: 960, minHeight: 720)
+        .frame(minWidth: 1180, minHeight: 820)
+        .animation(.spring(response: 0.45, dampingFraction: 0.85), value: summary != nil)
+    }
+
+    private var mainContent: some View {
+        VStack(spacing: 28) {
+            header
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            opponentsSection
+            centrePlayArea
+            humanSection
+            controlSection
+            footerSection
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 42)
+        .padding(.horizontal, 36)
+        .frame(maxWidth: 1320)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     private var backgroundView: some View {
@@ -43,65 +70,76 @@ struct ContentView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Spite & Malice")
-                .font(.system(size: 40, weight: .heavy, design: .rounded))
+                .font(.system(size: 42, weight: .heavy, design: .rounded))
                 .foregroundColor(.white)
             Text(viewModel.statusBanner)
-                .font(.system(size: 16, weight: .medium))
-                .foregroundColor(.white.opacity(0.85))
+                .font(.system(size: 17, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.9))
                 .textCase(nil)
         }
     }
 
     private var opponentsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 14) {
             ForEach(Array(viewModel.state.players.enumerated()).filter { !$0.element.isHuman }, id: \.element.id) { item in
                 OpponentAreaView(
                     player: item.element,
-                    isCurrentTurn: viewModel.state.currentPlayerIndex == item.offset
+                    isCurrentTurn: viewModel.state.currentPlayerIndex == item.offset,
+                    isStockRevealed: revealedStockPlayerIDs.contains(item.element.id),
+                    onToggleStockReveal: { toggleStockReveal(for: item.element.id) },
+                    revealedDiscardIndices: revealedDiscardIndices(for: item.element.id),
+                    onToggleDiscardReveal: { index in toggleDiscardReveal(for: item.element.id, pileIndex: index) }
                 )
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var centrePlayArea: some View {
-        VStack(spacing: 16) {
-            HStack(spacing: 20) {
+        VStack(spacing: 20) {
+            HStack(spacing: 24) {
                 ForEach(Array(viewModel.state.buildPiles.enumerated()), id: \.0) { index, pile in
                     BuildPileView(
                         pile: pile,
                         title: viewModel.buildPileTitle(for: index),
                         isActiveTarget: viewModel.isValidTarget(for: index),
-                        action: viewModel.state.currentPlayer.isHuman ? { viewModel.playSelectedCard(on: index) } : nil
+                        action: viewModel.state.currentPlayer.isHuman ? { viewModel.playSelectedCard(on: index) } : nil,
+                        isRevealed: revealedBuildPileIDs.contains(pile.id),
+                        onRevealToggle: { toggleBuildReveal(id: pile.id) }
                     )
                     .disabled(!viewModel.state.currentPlayer.isHuman)
                 }
+
                 DrawPileView(
                     drawCount: viewModel.state.drawPile.count,
                     recycleCount: viewModel.state.recyclePile.count
                 )
             }
+
             if viewModel.showsHelp {
                 helpPanel
             }
         }
+        .frame(maxWidth: .infinity)
     }
 
+    @ViewBuilder
     private var humanSection: some View {
         if let humanIndex = viewModel.state.players.firstIndex(where: { $0.isHuman }) {
             let player = viewModel.state.players[humanIndex]
-            return AnyView(
-                HumanPlayerAreaView(
-                    player: player,
-                    playerIndex: humanIndex,
-                    isCurrentTurn: viewModel.state.currentPlayerIndex == humanIndex,
-                    selection: viewModel.selection,
-                    onSelectStock: viewModel.selectStockCard,
-                    onTapDiscard: { index in viewModel.handleDiscardTap(index) },
-                    onSelectHandCard: { index in viewModel.selectHandCard(at: index) }
-                )
+            HumanPlayerAreaView(
+                player: player,
+                playerIndex: humanIndex,
+                isCurrentTurn: viewModel.state.currentPlayerIndex == humanIndex,
+                selection: viewModel.selection,
+                onSelectStock: viewModel.selectStockCard,
+                onTapDiscard: { index in viewModel.handleDiscardTap(index) },
+                onSelectHandCard: { index in viewModel.selectHandCard(at: index) },
+                isStockRevealed: revealedStockPlayerIDs.contains(player.id),
+                onToggleStockReveal: { toggleStockReveal(for: player.id) },
+                revealedDiscardIndices: revealedDiscardIndices(for: player.id),
+                onToggleDiscardReveal: { index in toggleDiscardReveal(for: player.id, pileIndex: index) }
             )
-        } else {
-            return AnyView(EmptyView())
         }
     }
 
@@ -109,22 +147,25 @@ struct ContentView: View {
         ControlPanelView(
             onNewGame: { viewModel.startNewGame() },
             onHint: viewModel.provideHint,
+            onUndo: viewModel.undoLastAction,
             onEndTurn: viewModel.endTurnIfPossible,
             isHintDisabled: !viewModel.state.currentPlayer.isHuman || viewModel.state.status != .playing,
+            isUndoDisabled: !viewModel.canUndoTurn,
             isEndTurnDisabled: !(viewModel.state.currentPlayer.isHuman && viewModel.state.phase == .waiting),
             showsHelp: $viewModel.showsHelp
         )
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     private var footerSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             Text("Recent activity")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.white.opacity(0.8))
+                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.85))
             ForEach(viewModel.activityLog()) { event in
                 Text(event.message)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(.white.opacity(0.65))
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.68))
             }
         }
     }
@@ -132,18 +173,52 @@ struct ContentView: View {
     private var helpPanel: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("How to play")
-                .font(.system(size: 14, weight: .bold))
+                .font(.system(size: 14, weight: .bold, design: .rounded))
                 .foregroundColor(.white)
             Text("Play cards from your stock, hand or discard piles to the shared build piles in ascending order from Ace to Queen. Kings are wild and take on any needed value. End your turn by discarding a card from your hand.")
-                .font(.system(size: 12))
+                .font(.system(size: 12, weight: .medium, design: .rounded))
                 .foregroundColor(.white.opacity(0.75))
         }
         .padding()
         .background(
-            RoundedRectangle(cornerRadius: 16)
+            RoundedRectangle(cornerRadius: 18)
                 .fill(Color.white.opacity(0.08))
         )
     }
+
+    private func toggleBuildReveal(id: UUID) {
+        withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
+            if revealedBuildPileIDs.contains(id) {
+                revealedBuildPileIDs.remove(id)
+            } else {
+                revealedBuildPileIDs.insert(id)
+            }
+        }
+    }
+
+    private func toggleStockReveal(for playerID: UUID) {
+        withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
+            if revealedStockPlayerIDs.contains(playerID) {
+                revealedStockPlayerIDs.remove(playerID)
+            } else {
+                revealedStockPlayerIDs.insert(playerID)
+            }
+        }
+    }
+
+    private func toggleDiscardReveal(for playerID: UUID, pileIndex: Int) {
+        let identifier = DiscardIdentifier(playerID: playerID, pileIndex: pileIndex)
+        withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
+            if revealedDiscardIdentifiers.contains(identifier) {
+                revealedDiscardIdentifiers.remove(identifier)
+            } else {
+                revealedDiscardIdentifiers.insert(identifier)
+            }
+        }
+    }
+
+    private func revealedDiscardIndices(for playerID: UUID) -> Set<Int> {
+        Set(revealedDiscardIdentifiers.filter { $0.playerID == playerID }.map(\.pileIndex))
+    }
 }
 #endif
-

--- a/Sources/SpiteAndMaliceApp/Views/ControlPanelView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ControlPanelView.swift
@@ -4,8 +4,10 @@ import SwiftUI
 struct ControlPanelView: View {
     var onNewGame: () -> Void
     var onHint: () -> Void
+    var onUndo: () -> Void
     var onEndTurn: () -> Void
     var isHintDisabled: Bool
+    var isUndoDisabled: Bool
     var isEndTurnDisabled: Bool
     @Binding var showsHelp: Bool
 
@@ -21,6 +23,12 @@ struct ControlPanelView: View {
             }
             .buttonStyle(.bordered)
             .disabled(isHintDisabled)
+
+            Button(action: onUndo) {
+                Label("Undo Move", systemImage: "arrow.uturn.backward")
+            }
+            .buttonStyle(.bordered)
+            .disabled(isUndoDisabled)
 
             Button(action: onEndTurn) {
                 Label("End Turn", systemImage: "flag.checkered")

--- a/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
@@ -8,42 +8,85 @@ struct DiscardPileView: View {
     var isHighlighted: Bool = false
     var isInteractive: Bool = false
     var action: (() -> Void)?
+    var isRevealed: Bool = false
+    var onRevealToggle: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 6) {
-            if let card = cards.last {
-                Button(action: { action?() }) {
-                    CardView(card: card, isHighlighted: isHighlighted, showsGlow: isHighlighted, scale: 0.95)
-                        .overlay(countBadge)
-                }
-                .buttonStyle(.plain)
-            } else {
-                Button(action: { action?() }) {
-                    CardPlaceholder(title: "Discard")
-                        .overlay(countBadge)
-                }
-                .buttonStyle(.plain)
-                .opacity(isInteractive ? 1 : 0.65)
-            }
+            discardContent
             Text(title)
                 .font(.system(size: 13, weight: .medium, design: .rounded))
                 .foregroundColor(.white.opacity(0.75))
         }
-        .opacity(isInteractive ? 1 : 0.85)
-        .animation(.easeInOut(duration: 0.15), value: cards.count)
+        .opacity(isInteractive ? 1 : 0.9)
+        .animation(.spring(response: 0.35, dampingFraction: 0.85), value: cards.count)
+    }
+
+    @ViewBuilder
+    private var discardContent: some View {
+        ZStack {
+            if isRevealed && !cards.isEmpty {
+                CardStackRevealView(cards: cards)
+            } else if let card = cards.last {
+                interactiveTopCard(card: card)
+            } else {
+                placeholderCard
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            if cards.count > 1 && !isRevealed {
+                countBadge
+            }
+        }
+        .overlay(alignment: .topLeading) {
+            if !cards.isEmpty, let onRevealToggle {
+                Button(action: onRevealToggle) {
+                    Image(systemName: isRevealed ? "eye.slash.fill" : "eye.fill")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundColor(.white)
+                        .padding(6)
+                        .background(Circle().fill(Color.black.opacity(0.55)))
+                }
+                .buttonStyle(.plain)
+                .padding(6)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func interactiveTopCard(card: Card) -> some View {
+        let view = CardView(card: card, isHighlighted: isHighlighted, showsGlow: isHighlighted, scale: 0.95)
+        if let action {
+            Button(action: action) {
+                view
+            }
+            .buttonStyle(.plain)
+        } else {
+            view
+        }
+    }
+
+    @ViewBuilder
+    private var placeholderCard: some View {
+        if let action {
+            Button(action: action) {
+                CardPlaceholder(title: "Discard")
+            }
+            .buttonStyle(.plain)
+            .opacity(isInteractive ? 1 : 0.65)
+        } else {
+            CardPlaceholder(title: "Discard")
+                .opacity(isInteractive ? 1 : 0.65)
+        }
     }
 
     private var countBadge: some View {
-        Group {
-            if cards.count > 1 {
-                Text("\(cards.count)")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundColor(.white)
-                    .padding(6)
-                    .background(Circle().fill(Color.black.opacity(0.45)))
-                    .offset(x: 24, y: -32)
-            }
-        }
+        Text("\(cards.count)")
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundColor(.white)
+            .padding(6)
+            .background(Circle().fill(Color.black.opacity(0.45)))
+            .offset(x: 22, y: -30)
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
@@ -10,6 +10,10 @@ struct HumanPlayerAreaView: View {
     var onSelectStock: () -> Void
     var onTapDiscard: (Int) -> Void
     var onSelectHandCard: (Int) -> Void
+    var isStockRevealed: Bool
+    var onToggleStockReveal: () -> Void
+    var revealedDiscardIndices: Set<Int>
+    var onToggleDiscardReveal: (Int) -> Void
 
     private var selectedDiscardIndex: Int? {
         guard let selection else { return nil }
@@ -22,11 +26,12 @@ struct HumanPlayerAreaView: View {
             PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
             HStack(alignment: .top, spacing: 18) {
                 StockPileView(
-                    card: player.stockTopCard,
-                    remainingCount: player.stockPile.count,
+                    cards: player.stockPile,
                     isFaceDown: false,
                     isHighlighted: selection?.origin.playerIndex == playerIndex && (selection?.origin.isStock ?? false),
-                    action: onSelectStock
+                    action: onSelectStock,
+                    isRevealed: isStockRevealed,
+                    onRevealToggle: onToggleStockReveal
                 )
 
                 HStack(spacing: 14) {
@@ -36,7 +41,9 @@ struct HumanPlayerAreaView: View {
                             title: "Discard \(index + 1)",
                             isHighlighted: selectedDiscardIndex == index,
                             isInteractive: true,
-                            action: { onTapDiscard(index) }
+                            action: { onTapDiscard(index) },
+                            isRevealed: revealedDiscardIndices.contains(index),
+                            onRevealToggle: { onToggleDiscardReveal(index) }
                         )
                     }
                 }

--- a/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
@@ -5,18 +5,23 @@ import SpiteAndMaliceCore
 struct OpponentAreaView: View {
     var player: Player
     var isCurrentTurn: Bool
+    var isStockRevealed: Bool
+    var onToggleStockReveal: () -> Void
+    var revealedDiscardIndices: Set<Int>
+    var onToggleDiscardReveal: (Int) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
             HStack(spacing: 18) {
                 StockPileView(
-                    card: player.stockTopCard,
-                    remainingCount: player.stockPile.count,
-                    isFaceDown: true,
-                    isHighlighted: isCurrentTurn
+                    cards: player.stockPile,
+                    isFaceDown: false,
+                    isHighlighted: isCurrentTurn,
+                    action: nil,
+                    isRevealed: isStockRevealed,
+                    onRevealToggle: onToggleStockReveal
                 )
-                .allowsHitTesting(false)
 
                 HStack(spacing: 14) {
                     ForEach(Array(player.discardPiles.indices), id: \.self) { index in
@@ -26,9 +31,10 @@ struct OpponentAreaView: View {
                             title: "Discard \(index + 1)",
                             isHighlighted: isCurrentTurn && !pile.isEmpty,
                             isInteractive: false,
-                            action: nil
+                            action: nil,
+                            isRevealed: revealedDiscardIndices.contains(index),
+                            onRevealToggle: { onToggleDiscardReveal(index) }
                         )
-                        .allowsHitTesting(false)
                     }
                 }
                 Spacer()

--- a/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
@@ -3,30 +3,79 @@ import SwiftUI
 import SpiteAndMaliceCore
 
 struct StockPileView: View {
-    var card: Card?
-    var remainingCount: Int
+    var cards: [Card]
     var isFaceDown: Bool
     var isHighlighted: Bool = false
     var action: (() -> Void)?
+    var isRevealed: Bool = false
+    var onRevealToggle: (() -> Void)?
+
+    private var remainingCount: Int { cards.count }
+    private var topCard: Card? { cards.last }
 
     var body: some View {
         VStack(spacing: 6) {
-            Button(action: { action?() }) {
-                ZStack {
-                    if let card {
-                        CardView(card: card, isFaceDown: isFaceDown, isHighlighted: isHighlighted, showsGlow: isHighlighted, scale: 1.05)
-                    } else {
-                        CardPlaceholder(title: "Stock")
+            stockContent
+                .overlay(alignment: .topTrailing) {
+                    if remainingCount > 0 && !isRevealed {
+                        countBadge
                     }
                 }
-                .overlay(countBadge)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(Text(accessibilityLabel))
+                .overlay(alignment: .topLeading) {
+                    if remainingCount > 0, let onRevealToggle {
+                        Button(action: onRevealToggle) {
+                            Image(systemName: isRevealed ? "eye.slash.fill" : "eye.fill")
+                                .font(.system(size: 16, weight: .bold))
+                                .foregroundColor(.white)
+                                .padding(6)
+                                .background(Circle().fill(Color.black.opacity(0.55)))
+                        }
+                        .buttonStyle(.plain)
+                        .padding(6)
+                    }
+                }
+                .accessibilityLabel(Text(accessibilityLabel))
+                .animation(.spring(response: 0.45, dampingFraction: 0.8), value: isRevealed)
 
             Text("Stock")
                 .font(.system(size: 13, weight: .semibold, design: .rounded))
                 .foregroundColor(.white.opacity(0.8))
+        }
+    }
+
+    @ViewBuilder
+    private var stockContent: some View {
+        if isRevealed && !cards.isEmpty {
+            CardStackRevealView(cards: cards)
+        } else if let card = topCard {
+            interactiveCard(for: card)
+        } else {
+            placeholderCard
+        }
+    }
+
+    @ViewBuilder
+    private func interactiveCard(for card: Card) -> some View {
+        let view = CardView(card: card, isFaceDown: isFaceDown, isHighlighted: isHighlighted, showsGlow: isHighlighted, scale: 1.05)
+        if let action, !isRevealed {
+            Button(action: action) {
+                view
+            }
+            .buttonStyle(.plain)
+        } else {
+            view
+        }
+    }
+
+    @ViewBuilder
+    private var placeholderCard: some View {
+        if let action, !isRevealed {
+            Button(action: action) {
+                CardPlaceholder(title: "Stock")
+            }
+            .buttonStyle(.plain)
+        } else {
+            CardPlaceholder(title: "Stock")
         }
     }
 
@@ -36,11 +85,13 @@ struct StockPileView: View {
             .foregroundColor(.white)
             .padding(6)
             .background(Circle().fill(Color.black.opacity(0.45)))
-            .offset(x: 28, y: -36)
+            .offset(x: 26, y: -32)
     }
 
     private var accessibilityLabel: String {
-        if let card, !isFaceDown {
+        if isRevealed {
+            return "Stock pile revealing all \(remainingCount) cards."
+        } else if let card = topCard, !isFaceDown {
             return "Stock pile showing \(card.value.accessibilityLabel) with \(remainingCount) cards remaining."
         } else {
             return "Stock pile with \(remainingCount) cards remaining."

--- a/Sources/SpiteAndMaliceApp/Views/WinOverlayView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/WinOverlayView.swift
@@ -1,0 +1,118 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct WinOverlayView: View {
+    let summary: GameViewModel.GameSummary
+    var onPlayAgain: () -> Void
+
+    private var titleText: String {
+        summary.winner.isHuman ? "You Win!" : "\(summary.winner.name) Wins"
+    }
+
+    private var subtitleText: String {
+        let turnWord = summary.totalTurns == 1 ? "turn" : "turns"
+        let buildWord = summary.buildPilesCompleted == 1 ? "build pile" : "build piles"
+        return "Game finished in \(summary.totalTurns) \(turnWord) with \(summary.buildPilesCompleted) completed \(buildWord)."
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.65)
+                .ignoresSafeArea()
+
+            VStack(spacing: 28) {
+                VStack(spacing: 8) {
+                    Text(titleText)
+                        .font(.system(size: 44, weight: .heavy, design: .rounded))
+                        .foregroundColor(.white)
+                    Text(subtitleText)
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.85))
+                        .multilineTextAlignment(.center)
+                }
+
+                playerStats
+
+                Button(action: onPlayAgain) {
+                    Label("Play Again", systemImage: "arrow.clockwise.circle.fill")
+                        .font(.system(size: 18, weight: .semibold, design: .rounded))
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Color.white.opacity(0.2))
+                .foregroundStyle(.white)
+            }
+            .padding(40)
+            .frame(maxWidth: 620)
+            .background(
+                RoundedRectangle(cornerRadius: 36, style: .continuous)
+                    .fill(.ultraThinMaterial)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 36, style: .continuous)
+                    .stroke(Color.white.opacity(0.25), lineWidth: 1.5)
+            )
+            .shadow(color: Color.black.opacity(0.35), radius: 24, x: 0, y: 12)
+            .padding(.horizontal, 24)
+        }
+    }
+
+    private var playerStats: some View {
+        VStack(spacing: 18) {
+            ForEach(summary.players) { player in
+                playerCard(for: player)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func playerCard(for player: GameViewModel.PlayerSummary) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Text(player.name)
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                if player.isWinner {
+                    Image(systemName: "crown.fill")
+                        .foregroundColor(.yellow)
+                }
+                Spacer()
+                Text(player.isHuman ? "You" : "Opponent")
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+
+            Divider()
+                .overlay(Color.white.opacity(0.25))
+
+            statRow(icon: "rectangle.stack.fill", label: "Stock remaining", value: "\(player.stockRemaining)")
+            statRow(icon: "checkmark.circle.fill", label: "Stock cards cleared", value: "\(player.completedStockCards)")
+            statRow(icon: "suit.club.fill", label: "Cards played", value: "\(player.cardsPlayed)")
+            statRow(icon: "arrow.down.circle.fill", label: "Cards discarded", value: "\(player.cardsDiscarded)")
+            statRow(icon: "hand.draw.fill", label: "Hand cards", value: "\(player.handCount)")
+            statRow(icon: "tray.full.fill", label: "Discard pile cards", value: "\(player.discardCardCount)")
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.white.opacity(player.isWinner ? 0.18 : 0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .stroke(Color.white.opacity(player.isWinner ? 0.4 : 0.25), lineWidth: 1)
+        )
+    }
+
+    private func statRow(icon: String, label: String, value: String) -> some View {
+        HStack {
+            Label(label, systemImage: icon)
+                .font(.system(size: 13, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.78))
+            Spacer()
+            Text(value)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundColor(.white)
+        }
+    }
+}
+#endif

--- a/Sources/SpiteAndMaliceCore/Models/Player.swift
+++ b/Sources/SpiteAndMaliceCore/Models/Player.swift
@@ -9,6 +9,8 @@ public struct Player: Identifiable, Codable, Equatable {
     public var hand: [Card]
     public var score: Int
     public var completedStockCards: Int
+    public var cardsPlayed: Int
+    public var cardsDiscarded: Int
 
     public init(
         id: UUID = UUID(),
@@ -18,7 +20,9 @@ public struct Player: Identifiable, Codable, Equatable {
         discardPiles: [[Card]] = Array(repeating: [], count: 4),
         hand: [Card] = [],
         score: Int = 0,
-        completedStockCards: Int = 0
+        completedStockCards: Int = 0,
+        cardsPlayed: Int = 0,
+        cardsDiscarded: Int = 0
     ) {
         self.id = id
         self.name = name
@@ -28,6 +32,8 @@ public struct Player: Identifiable, Codable, Equatable {
         self.hand = hand
         self.score = score
         self.completedStockCards = completedStockCards
+        self.cardsPlayed = cardsPlayed
+        self.cardsDiscarded = cardsDiscarded
     }
 
     public var stockTopCard: Card? { stockPile.last }


### PR DESCRIPTION
## Summary
- fix stock pile play validation and record per-player card stats in the engine
- add turn-limited undo support, track game summaries, and surface a win overlay with detailed statistics
- widen and center the layout, expose opponent stock tops, and add reveal animations for build, stock, and discard piles

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68c910f81ea88329af6a78df9614cfb3