### PR TITLE
Improve gameplay flow and layout

### DIFF
--- a/Sources/SpiteAndMaliceApp/Views/BuildPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/BuildPileView.swift
@@ -47,7 +47,7 @@ struct BuildPileView: View {
     private var pileContent: some View {
         if isRevealed && cardCount > 0 {
             CardStackRevealView(cards: pile.cards.map { $0.card })
-        } else if let top = pile.topCard?.card {
+        } else if let top = pile.topCard {
             interactiveCard(for: top)
         } else {
             placeholderCard
@@ -55,8 +55,14 @@ struct BuildPileView: View {
     }
 
     @ViewBuilder
-    private func interactiveCard(for card: Card) -> some View {
-        let view = CardView(card: card, isHighlighted: isActiveTarget, showsGlow: isActiveTarget)
+    private func interactiveCard(for playedCard: PlayedCard) -> some View {
+        let resolvedOverride = playedCard.card.isWild ? playedCard.resolvedValue : nil
+        let view = CardView(
+            card: playedCard.card,
+            isHighlighted: isActiveTarget,
+            showsGlow: isActiveTarget,
+            resolvedValueOverride: resolvedOverride
+        )
         if let action {
             Button(action: action) {
                 view

--- a/Sources/SpiteAndMaliceApp/Views/CardView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/CardView.swift
@@ -9,8 +9,11 @@ struct CardView: View {
     var isHighlighted: Bool = false
     var showsGlow: Bool = false
     var scale: CGFloat = 1
+    var resolvedValueOverride: CardValue?
 
     private var baseSize: CGSize { CGSize(width: 70, height: 98) }
+    private var usesResolvedOverride: Bool { card.isWild && resolvedValueOverride != nil }
+    private var resolvedValue: CardValue? { usesResolvedOverride ? resolvedValueOverride : nil }
 
     var body: some View {
         let size = CGSize(width: baseSize.width * scale, height: baseSize.height * scale)
@@ -34,24 +37,23 @@ struct CardView: View {
                         .foregroundColor(.white.opacity(0.8))
                 }
             } else {
-                VStack(spacing: 4) {
-                    Text(card.displayName)
-                        .font(.system(size: 34, weight: .heavy, design: .rounded))
+                VStack(spacing: usesResolvedOverride ? 6 : 4) {
+                    Text(primaryLabel)
+                        .font(.system(size: usesResolvedOverride ? 40 : 34, weight: .heavy, design: .rounded))
                         .foregroundColor(CardPalette.textColor(for: card))
                         .shadow(radius: 1.5)
-                    if card.isWild {
-                        Text("Wild King")
-                            .font(.system(size: 13, weight: .semibold, design: .rounded))
-                            .foregroundColor(.white.opacity(0.9))
-                    } else {
-                        Text(card.value.accessibilityLabel)
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundColor(.white.opacity(0.85))
-                    }
+                    subtitleView
                 }
             }
         }
         .frame(width: size.width, height: size.height)
+        .overlay(alignment: .topLeading) {
+            if usesResolvedOverride {
+                KingBadge()
+                    .offset(x: 8, y: 8)
+            }
+        }
+        .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .animation(.easeInOut(duration: 0.2), value: isSelected)
     }
 
@@ -64,19 +66,71 @@ struct CardView: View {
             return Color.white.opacity(0.6)
         }
     }
+
+    @ViewBuilder
+    private var subtitleView: some View {
+        if let resolvedValue {
+            HStack(spacing: 6) {
+                Image(systemName: "crown.fill")
+                    .font(.system(size: 12, weight: .bold))
+                Text("King as \(resolvedValue.accessibilityLabel)")
+            }
+            .font(.system(size: 12.5, weight: .semibold, design: .rounded))
+            .foregroundColor(.white.opacity(0.92))
+        } else if card.isWild {
+            Text("Wild King")
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.9))
+        } else {
+            Text(card.value.accessibilityLabel)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.white.opacity(0.85))
+        }
+    }
+
+    private var primaryLabel: String {
+        if let resolvedValue {
+            return resolvedValue.label
+        }
+        return card.displayName
+    }
 }
 
 struct CardPlaceholder: View {
     var title: String
     var body: some View {
         RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .stroke(Color.white.opacity(0.3), style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
+            .fill(Color.white.opacity(0.05))
             .frame(width: 70, height: 98)
             .overlay(
-                Text(title)
-                    .font(.system(size: 12, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.6))
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.white.opacity(0.32), style: StrokeStyle(lineWidth: 2, dash: [6, 4]))
             )
+            .overlay(
+                Text(title)
+                    .multilineTextAlignment(.center)
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.68))
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+private struct KingBadge: View {
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "crown.fill")
+                .font(.system(size: 13, weight: .bold))
+            Text("King")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .foregroundColor(.white)
+        .background(
+            Capsule(style: .continuous)
+                .fill(Color.black.opacity(0.55))
+        )
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/ContentView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ContentView.swift
@@ -10,7 +10,6 @@ private struct DiscardIdentifier: Hashable {
 struct ContentView: View {
     @EnvironmentObject private var viewModel: GameViewModel
     @State private var revealedBuildPileIDs: Set<UUID> = []
-    @State private var revealedStockPlayerIDs: Set<UUID> = []
     @State private var revealedDiscardIdentifiers: Set<DiscardIdentifier> = []
 
     var body: some View {
@@ -43,7 +42,7 @@ struct ContentView: View {
     }
 
     private var mainContent: some View {
-        VStack(spacing: 28) {
+        VStack(spacing: 32) {
             header
                 .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -52,11 +51,10 @@ struct ContentView: View {
             humanSection
             controlSection
             footerSection
-                .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.vertical, 42)
-        .padding(.horizontal, 36)
-        .frame(maxWidth: 1320)
+        .padding(.vertical, 48)
+        .padding(.horizontal, 32)
+        .frame(maxWidth: 1240)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
@@ -82,7 +80,7 @@ struct ContentView: View {
     }
 
     private var opponentsSection: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 18) {
             ForEach(Array(viewModel.state.players.enumerated()).filter { !$0.element.isHuman }, id: \.element.id) { item in
                 OpponentAreaView(
                     player: item.element,
@@ -92,12 +90,12 @@ struct ContentView: View {
                 )
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     private var centrePlayArea: some View {
-        VStack(spacing: 20) {
-            HStack(spacing: 24) {
+        VStack(spacing: 24) {
+            HStack(spacing: 28) {
                 ForEach(Array(viewModel.state.buildPiles.enumerated()), id: \.0) { index, pile in
                     BuildPileView(
                         pile: pile,
@@ -156,16 +154,16 @@ struct ContentView: View {
     }
 
     private var footerSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Recent activity")
-                .font(.system(size: 15, weight: .semibold, design: .rounded))
-                .foregroundColor(.white.opacity(0.85))
-            ForEach(viewModel.activityLog()) { event in
-                Text(event.message)
-                    .font(.system(size: 12, weight: .medium, design: .rounded))
-                    .foregroundColor(.white.opacity(0.68))
-            }
+        VStack(spacing: 20) {
+            ScoreboardView(
+                players: viewModel.state.players,
+                currentPlayerIndex: viewModel.state.currentPlayerIndex,
+                turn: viewModel.state.turn
+            )
+
+            RecentActivityView(events: viewModel.activityLog())
         }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     private var helpPanel: some View {
@@ -190,16 +188,6 @@ struct ContentView: View {
                 revealedBuildPileIDs.remove(id)
             } else {
                 revealedBuildPileIDs.insert(id)
-            }
-        }
-    }
-
-    private func toggleStockReveal(for playerID: UUID) {
-        withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
-            if revealedStockPlayerIDs.contains(playerID) {
-                revealedStockPlayerIDs.remove(playerID)
-            } else {
-                revealedStockPlayerIDs.insert(playerID)
             }
         }
     }

--- a/Sources/SpiteAndMaliceApp/Views/HandView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HandView.swift
@@ -24,6 +24,7 @@ struct HandView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
@@ -20,9 +20,10 @@ struct HumanPlayerAreaView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(spacing: 20) {
             PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
-            HStack(alignment: .top, spacing: 18) {
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(alignment: .top, spacing: 22) {
                 StockPileView(
                     cards: player.stockPile,
                     isFaceDown: false,
@@ -30,7 +31,7 @@ struct HumanPlayerAreaView: View {
                     action: onSelectStock
                 )
 
-                HStack(spacing: 14) {
+                HStack(spacing: 18) {
                     ForEach(Array(player.discardPiles.indices), id: \.self) { index in
                         DiscardPileView(
                             cards: player.discardPiles[index],
@@ -43,20 +44,23 @@ struct HumanPlayerAreaView: View {
                         )
                     }
                 }
-                Spacer()
             }
+            .frame(maxWidth: .infinity, alignment: .center)
 
             HandView(
                 cards: player.hand,
                 selectedCardID: selection?.card.id,
                 tapAction: onSelectHandCard
             )
+            .frame(maxWidth: .infinity, alignment: .center)
         }
-        .padding()
+        .padding(.vertical, 22)
+        .padding(.horizontal, 24)
         .background(
             RoundedRectangle(cornerRadius: 20)
                 .fill(Color.white.opacity(0.08))
         )
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
@@ -9,9 +9,10 @@ struct OpponentAreaView: View {
     var onToggleDiscardReveal: (Int) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(spacing: 18) {
             PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
-            HStack(spacing: 18) {
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack(spacing: 22) {
                 StockPileView(
                     cards: player.stockPile,
                     isFaceDown: false,
@@ -19,7 +20,7 @@ struct OpponentAreaView: View {
                     action: nil
                 )
 
-                HStack(spacing: 14) {
+                HStack(spacing: 18) {
                     ForEach(Array(player.discardPiles.indices), id: \.self) { index in
                         let pile = player.discardPiles[index]
                         DiscardPileView(
@@ -33,14 +34,16 @@ struct OpponentAreaView: View {
                         )
                     }
                 }
-                Spacer()
             }
+            .frame(maxWidth: .infinity, alignment: .center)
         }
-        .padding()
+        .padding(.vertical, 20)
+        .padding(.horizontal, 22)
         .background(
             RoundedRectangle(cornerRadius: 20)
                 .fill(Color.white.opacity(0.05))
         )
+        .frame(maxWidth: .infinity)
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/RecentActivityView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/RecentActivityView.swift
@@ -1,0 +1,79 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import SpiteAndMaliceCore
+
+struct RecentActivityView: View {
+    var events: [GameEvent]
+
+    private static let formatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Recent activity")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.9))
+                Spacer()
+            }
+
+            if events.isEmpty {
+                Text("No moves yet. Play a card to get things going!")
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.65))
+            } else {
+                VStack(spacing: 14) {
+                    ForEach(events) { event in
+                        ActivityRow(event: event)
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 22)
+                .fill(Color.white.opacity(0.04))
+        )
+    }
+
+    private struct ActivityRow: View {
+        var event: GameEvent
+
+        var body: some View {
+            HStack(alignment: .top, spacing: 12) {
+                Circle()
+                    .fill(Color.blue.opacity(0.55))
+                    .frame(width: 10, height: 10)
+                    .padding(.top, 6)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(event.message)
+                        .font(.system(size: 13, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.82))
+                        .multilineTextAlignment(.leading)
+                    Text(Self.relativeTime(from: event.timestamp))
+                        .font(.system(size: 11.5, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.55))
+                }
+
+                Spacer()
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color.white.opacity(0.02))
+            )
+        }
+
+        private static func relativeTime(from date: Date) -> String {
+            let now = Date()
+            let formatted = RecentActivityView.formatter.localizedString(for: date, relativeTo: now)
+            return formatted
+        }
+    }
+}
+#endif

--- a/Sources/SpiteAndMaliceApp/Views/ScoreboardView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ScoreboardView.swift
@@ -1,0 +1,107 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import SpiteAndMaliceCore
+
+struct ScoreboardView: View {
+    var players: [Player]
+    var currentPlayerIndex: Int
+    var turn: Int
+
+    private var columns: [GridItem] { [GridItem(.adaptive(minimum: 240), spacing: 16)] }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Scoreboard")
+                    .font(.system(size: 18, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.9))
+                Spacer()
+                Text("Turn \(turn)")
+                    .font(.system(size: 13, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.7))
+            }
+
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(Array(players.enumerated()), id: \.element.id) { index, player in
+                    ScoreboardPlayerCard(
+                        player: player,
+                        isCurrent: index == currentPlayerIndex
+                    )
+                }
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 22)
+                .fill(Color.white.opacity(0.06))
+        )
+    }
+}
+
+private struct ScoreboardPlayerCard: View {
+    var player: Player
+    var isCurrent: Bool
+
+    private var discardCount: Int { player.discardPiles.reduce(0) { $0 + $1.count } }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 10) {
+                Text(player.name)
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white)
+                if player.isHuman {
+                    Text("You")
+                        .font(.system(size: 11, weight: .bold, design: .rounded))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(Color.blue.opacity(0.45)))
+                }
+                Spacer()
+                if isCurrent {
+                    Label("Active", systemImage: "flame.fill")
+                        .font(.system(size: 11.5, weight: .semibold, design: .rounded))
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(Color.yellow.opacity(0.45)))
+                        .foregroundColor(.white)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                statRow(icon: "rectangle.stack.fill", label: "Stock", value: "\(player.stockPile.count)")
+                statRow(icon: "hand.tap.fill", label: "Hand", value: "\(player.hand.count)")
+                statRow(icon: "tray.full.fill", label: "Discard", value: "\(discardCount)")
+                statRow(icon: "checkmark.seal.fill", label: "Stock cleared", value: "\(player.completedStockCards)")
+                statRow(icon: "arrow.up.circle.fill", label: "Cards played", value: "\(player.cardsPlayed)")
+                statRow(icon: "arrow.down.circle.fill", label: "Cards discarded", value: "\(player.cardsDiscarded)")
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(Color.white.opacity(0.05))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18)
+                        .stroke(isCurrent ? Color.yellow.opacity(0.45) : Color.white.opacity(0.08), lineWidth: isCurrent ? 2 : 1)
+                )
+        )
+    }
+
+    private func statRow(icon: String, label: String, value: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .semibold))
+                .frame(width: 18)
+                .foregroundColor(.white.opacity(0.75))
+            Text(label)
+                .font(.system(size: 12.5, weight: .medium, design: .rounded))
+                .foregroundColor(.white.opacity(0.72))
+            Spacer()
+            Text(value)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.95))
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- auto-refill a player's hand when they exhaust their draws and log the refresh as well as wild king plays
- let players toggle card selections, auto-end a turn after discarding, and refresh the activity feed order
- polish the table layout, enlarge card hit targets, and add dedicated scoreboard and recent activity panels with clearer king indicators on build piles

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ca4575265c83299fe9121d0c038ea1