### PR TITLE
Revamp pile layout, hinting, and controls

### DIFF
--- a/Sources/SpiteAndMaliceApp/SpiteAndMaliceApp.swift
+++ b/Sources/SpiteAndMaliceApp/SpiteAndMaliceApp.swift
@@ -33,15 +33,7 @@ struct SpiteAndMaliceApp: App {
                     viewModel.provideHint()
                 }
                 .keyboardShortcut("h", modifiers: [.command])
-                .disabled(
-                    !(viewModel.state.currentPlayer.isHuman && viewModel.state.status == .playing) ||
-                    viewModel.hint != nil
-                )
-
-                Toggle(isOn: $viewModel.showsHelp) {
-                    Text("Show Help Panel")
-                }
-                .keyboardShortcut("?", modifiers: [.shift, .command])
+                .disabled(!(viewModel.state.currentPlayer.isHuman && viewModel.state.status == .playing))
             }
             CommandGroup(after: .windowArrangement) {
                 Button("Toggle Full Screen") {

--- a/Sources/SpiteAndMaliceApp/Views/BuildPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/BuildPileView.swift
@@ -7,36 +7,13 @@ struct BuildPileView: View {
     var title: String
     var isActiveTarget: Bool
     var action: (() -> Void)?
-    var isRevealed: Bool = false
-    var onRevealToggle: (() -> Void)?
 
     private var cardCount: Int { pile.cards.count }
 
     var body: some View {
         VStack(spacing: 10) {
             pileContent
-                .overlay(alignment: .top) {
-                    if cardCount >= 2 {
-                        PilePeekHandle(action: onRevealToggle) {
-                            HStack(alignment: .center, spacing: 8) {
-                                VStack(spacing: 2) {
-                                    Text("\(cardCount)")
-                                        .font(.system(size: 13, weight: .semibold, design: .rounded))
-                                    Text("of \(BuildPile.targetSequenceCount)")
-                                        .font(.system(size: 10, weight: .medium, design: .rounded))
-                                        .opacity(0.8)
-                                }
-                                if onRevealToggle != nil {
-                                    Image(systemName: isRevealed ? "chevron.up" : "chevron.down")
-                                        .font(.system(size: 11, weight: .bold))
-                                }
-                            }
-                        }
-                        .offset(y: -22)
-                    }
-                }
                 .accessibilityLabel(Text(pileAccessibilityLabel))
-                .animation(.spring(response: 0.45, dampingFraction: 0.8), value: isRevealed)
 
             Text(title)
                 .font(.system(size: 14, weight: .semibold, design: .rounded))
@@ -46,10 +23,18 @@ struct BuildPileView: View {
 
     @ViewBuilder
     private var pileContent: some View {
-        if isRevealed && cardCount > 0 {
-            CardStackRevealView(cards: pile.cards.map { $0.card })
-        } else if let top = pile.topCard {
-            interactiveCard(for: top)
+        if let top = pile.topCard {
+            ZStack(alignment: .top) {
+                if cardCount > 1 {
+                    PeekingCardStack(
+                        cards: Array(pile.cards.dropLast().map { $0.card }),
+                        isFaceDown: false,
+                        scale: 0.94
+                    )
+                }
+                interactiveCard(for: top)
+            }
+            .padding(.top, PeekingCardStack.padding(forCardCount: max(cardCount - 1, 0)))
         } else {
             placeholderCard
         }
@@ -76,7 +61,7 @@ struct BuildPileView: View {
 
     @ViewBuilder
     private var placeholderCard: some View {
-        let placeholder = CardPlaceholder(title: "Start with\nAce")
+        let placeholder = CardPlaceholder(title: "Start\nwith 1")
             .overlay(
                 RoundedRectangle(cornerRadius: 14)
                     .stroke(isActiveTarget ? Color.yellow : Color.white.opacity(0.2), lineWidth: isActiveTarget ? 3 : 1)

--- a/Sources/SpiteAndMaliceApp/Views/CardView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/CardView.swift
@@ -37,7 +37,7 @@ struct CardView: View {
                         .foregroundColor(.white.opacity(0.8))
                 }
             } else {
-                VStack(spacing: usesResolvedOverride ? 6 : 4) {
+                VStack(spacing: (usesResolvedOverride || card.isWild) ? 6 : 0) {
                     Text(primaryLabel)
                         .font(.system(size: usesResolvedOverride ? 40 : 34, weight: .heavy, design: .rounded))
                         .foregroundColor(CardPalette.textColor(for: card))
@@ -78,13 +78,9 @@ struct CardView: View {
             .font(.system(size: 12.5, weight: .semibold, design: .rounded))
             .foregroundColor(.white.opacity(0.92))
         } else if card.isWild {
-            Text("Wild King")
+            Text("Wild")
                 .font(.system(size: 13, weight: .semibold, design: .rounded))
                 .foregroundColor(.white.opacity(0.9))
-        } else {
-            Text(card.value.accessibilityLabel)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(.white.opacity(0.85))
         }
     }
 

--- a/Sources/SpiteAndMaliceApp/Views/ControlPanelView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ControlPanelView.swift
@@ -8,7 +8,6 @@ struct ControlPanelView: View {
     var isHintDisabled: Bool
     var isHintActive: Bool
     var isUndoDisabled: Bool
-    @Binding var showsHelp: Bool
 
     var body: some View {
         HStack(spacing: 16) {
@@ -24,12 +23,6 @@ struct ControlPanelView: View {
             }
             .buttonStyle(.bordered)
             .disabled(isUndoDisabled)
-
-            Toggle(isOn: $showsHelp.animation()) {
-                Label("Show Help", systemImage: "questionmark.circle")
-            }
-            .toggleStyle(.switch)
-            .foregroundStyle(.white.opacity(0.85))
         }
     }
 
@@ -41,7 +34,6 @@ struct ControlPanelView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(Color.yellow.opacity(0.85))
-            .disabled(true)
         } else {
             Button(action: onHint) {
                 Label("Hint", systemImage: "lightbulb")

--- a/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
@@ -8,8 +8,6 @@ struct DiscardPileView: View {
     var isHighlighted: Bool = false
     var isInteractive: Bool = false
     var action: (() -> Void)?
-    var isRevealed: Bool = false
-    var onRevealToggle: (() -> Void)?
 
     var body: some View {
         VStack(spacing: 6) {
@@ -24,30 +22,22 @@ struct DiscardPileView: View {
 
     @ViewBuilder
     private var discardContent: some View {
-        ZStack {
-            if isRevealed && !cards.isEmpty {
-                CardStackRevealView(cards: cards)
-            } else if let card = cards.last {
+        ZStack(alignment: .top) {
+            if cards.count > 1 {
+                PeekingCardStack(
+                    cards: Array(cards.dropLast()),
+                    isFaceDown: false,
+                    scale: 0.92
+                )
+            }
+
+            if let card = cards.last {
                 interactiveTopCard(card: card)
             } else {
                 placeholderCard
             }
         }
-        .overlay(alignment: .top) {
-            if cards.count >= 2 {
-                PilePeekHandle(action: onRevealToggle) {
-                    HStack(spacing: 8) {
-                        Text("\(cards.count)")
-                            .font(.system(size: 12, weight: .semibold, design: .rounded))
-                        if onRevealToggle != nil {
-                            Image(systemName: isRevealed ? "chevron.up" : "chevron.down")
-                                .font(.system(size: 11, weight: .bold))
-                        }
-                    }
-                }
-                .offset(y: -20)
-            }
-        }
+        .padding(.top, PeekingCardStack.padding(forCardCount: max(cards.count - 1, 0)))
     }
 
     @ViewBuilder

--- a/Sources/SpiteAndMaliceApp/Views/HintOverlayView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HintOverlayView.swift
@@ -3,30 +3,59 @@ import SwiftUI
 
 struct HintOverlayView: View {
     var message: String
-    var onDismiss: (() -> Void)? = nil
+    var recommendations: [GameViewModel.Hint.Recommendation]
 
     var body: some View {
-        HStack(spacing: 12) {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "lightbulb.fill")
+                    .font(.system(size: 14, weight: .bold))
+                Text("Tip")
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+            }
+            .foregroundColor(.black.opacity(0.85))
+
             Text(message)
                 .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundColor(.black)
+                .foregroundColor(.black.opacity(0.92))
+                .fixedSize(horizontal: false, vertical: true)
 
-            if let onDismiss {
-                Button(action: onDismiss) {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 16, weight: .bold))
-                        .foregroundColor(.black.opacity(0.65))
+            if !recommendations.isEmpty {
+                Divider()
+                    .background(Color.black.opacity(0.15))
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Top plays")
+                        .font(.system(size: 12.5, weight: .bold, design: .rounded))
+                        .foregroundColor(.black.opacity(0.7))
+
+                    ForEach(recommendations, id: \.rank) { recommendation in
+                        HStack(alignment: .top, spacing: 10) {
+                            Text("\(recommendation.rank)")
+                                .font(.system(size: 13, weight: .bold, design: .rounded))
+                                .padding(6)
+                                .background(Circle().fill(Color.black.opacity(0.08)))
+                                .foregroundColor(.black.opacity(0.75))
+
+                            Text(recommendation.detail)
+                                .font(.system(size: 12.5, weight: .semibold, design: .rounded))
+                                .foregroundColor(.black.opacity(0.78))
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel(Text("Dismiss hint"))
             }
+
+            Text("Tap the Hint button again to dismiss.")
+                .font(.system(size: 11.5, weight: .medium, design: .rounded))
+                .foregroundColor(.black.opacity(0.6))
         }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
         .background(
-            Capsule()
-                .fill(Color.yellow.opacity(0.85))
-                .shadow(color: Color.black.opacity(0.25), radius: 6, x: 0, y: 3)
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(Color.yellow.opacity(0.9))
+                .shadow(color: Color.black.opacity(0.25), radius: 10, x: 0, y: 4)
         )
         .padding(.top, 8)
         .transition(.opacity.combined(with: .scale))

--- a/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
@@ -10,8 +10,6 @@ struct HumanPlayerAreaView: View {
     var onSelectStock: () -> Void
     var onTapDiscard: (Int) -> Void
     var onSelectHandCard: (Int) -> Void
-    var revealedDiscardIndices: Set<Int>
-    var onToggleDiscardReveal: (Int) -> Void
 
     private var selectedDiscardIndex: Int? {
         guard let selection else { return nil }
@@ -35,17 +33,15 @@ struct HumanPlayerAreaView: View {
                     ForEach(Array(player.discardPiles.indices), id: \.self) { index in
                         DiscardPileView(
                             cards: player.discardPiles[index],
-                            title: "Discard \(index + 1)",
+                            title: "Discard",
                             isHighlighted: selectedDiscardIndex == index,
                             isInteractive: true,
-                            action: { onTapDiscard(index) },
-                            isRevealed: revealedDiscardIndices.contains(index),
-                            onRevealToggle: { onToggleDiscardReveal(index) }
+                            action: { onTapDiscard(index) }
                         )
                     }
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .center)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             HandView(
                 cards: player.hand,

--- a/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
@@ -5,8 +5,6 @@ import SpiteAndMaliceCore
 struct OpponentAreaView: View {
     var player: Player
     var isCurrentTurn: Bool
-    var revealedDiscardIndices: Set<Int>
-    var onToggleDiscardReveal: (Int) -> Void
 
     var body: some View {
         VStack(spacing: 18) {
@@ -25,17 +23,15 @@ struct OpponentAreaView: View {
                         let pile = player.discardPiles[index]
                         DiscardPileView(
                             cards: pile,
-                            title: "Discard \(index + 1)",
+                            title: "Discard",
                             isHighlighted: isCurrentTurn && !pile.isEmpty,
                             isInteractive: false,
-                            action: nil,
-                            isRevealed: revealedDiscardIndices.contains(index),
-                            onRevealToggle: { onToggleDiscardReveal(index) }
+                            action: nil
                         )
                     }
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .center)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 20)
         .padding(.horizontal, 22)

--- a/Sources/SpiteAndMaliceApp/Views/PeekingCardStack.swift
+++ b/Sources/SpiteAndMaliceApp/Views/PeekingCardStack.swift
@@ -1,0 +1,33 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import SpiteAndMaliceCore
+
+struct PeekingCardStack: View {
+    static let defaultPeekHeight: CGFloat = 14
+    static let defaultMaxPeekCount: Int = 3
+
+    var cards: [Card]
+    var isFaceDown: Bool
+    var scale: CGFloat
+
+    private var visibleCards: [Card] {
+        Array(cards.suffix(Self.defaultMaxPeekCount))
+    }
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            ForEach(Array(visibleCards.enumerated()), id: \.element.id) { index, card in
+                let offsetAmount = CGFloat(visibleCards.count - index) * Self.defaultPeekHeight
+                CardView(card: card, isFaceDown: isFaceDown, scale: scale)
+                    .opacity(0.55 + (Double(index) * 0.12))
+                    .offset(y: -offsetAmount)
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    static func padding(forCardCount count: Int) -> CGFloat {
+        CGFloat(min(count, defaultMaxPeekCount)) * defaultPeekHeight
+    }
+}
+#endif

--- a/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
@@ -31,11 +31,21 @@ struct StockPileView: View {
 
     @ViewBuilder
     private var stockContent: some View {
-        if let card = topCard {
-            interactiveCard(for: card)
-        } else {
-            placeholderCard
+        ZStack(alignment: .top) {
+            if let card = topCard {
+                if remainingCount > 1 {
+                    PeekingCardStack(
+                        cards: Array(cards.dropLast()),
+                        isFaceDown: isFaceDown,
+                        scale: 0.98
+                    )
+                }
+                interactiveCard(for: card)
+            } else {
+                placeholderCard
+            }
         }
+        .padding(.top, PeekingCardStack.padding(forCardCount: max(remainingCount - 1, 0)))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- stack stock, discard, and build piles with a new peeking card stack instead of reveal toggles
- align player areas with the build piles, remove numbered pile labels, and give sidebars more breathing room
- modernize the hint system and controls with toggleable hints, top-three recommendations, and simplified card text

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ca57f40ca483299c6cebf7e7f2a5ce