### PR TITLE
Improve play area layout and add zoom control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.xcodeproj/xcuserdata/
+.build/

--- a/Sources/SpiteAndMaliceApp/Views/CardView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/CardView.swift
@@ -19,7 +19,7 @@ struct CardView: View {
         let size = CGSize(width: baseSize.width * scale, height: baseSize.height * scale)
         ZStack {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(isFaceDown ? AnyShapeStyle(Color.gray.opacity(0.5)) : AnyShapeStyle(CardPalette.background(for: card)))
+                .fill(isFaceDown ? faceDownBackground : AnyShapeStyle(CardPalette.background(for: card)))
                 .overlay(
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
                         .stroke(borderColor, lineWidth: isSelected ? 4 : 2)
@@ -65,6 +65,16 @@ struct CardView: View {
         } else {
             return Color.white.opacity(0.6)
         }
+    }
+
+    private var faceDownBackground: AnyShapeStyle {
+        AnyShapeStyle(
+            LinearGradient(
+                colors: [Color(red: 0.27, green: 0.31, blue: 0.43), Color(red: 0.19, green: 0.22, blue: 0.33)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
     }
 
     @ViewBuilder

--- a/Sources/SpiteAndMaliceApp/Views/ContentView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ContentView.swift
@@ -5,31 +5,31 @@ import SpiteAndMaliceCore
 struct ContentView: View {
     @EnvironmentObject private var viewModel: GameViewModel
 
+    @State private var zoomScale: CGFloat = 1.0
+
     var body: some View {
         let summary = viewModel.gameSummary
         ZStack(alignment: .top) {
             backgroundView
             ScrollView(.vertical, showsIndicators: true) {
                 mainContent
+                    .scaleEffect(zoomScale, anchor: .top)
+                    .padding(.top, 16)
                     .frame(maxWidth: .infinity)
             }
             .blur(radius: summary == nil ? 0 : 8)
             .allowsHitTesting(summary == nil)
-
-            if let hint = viewModel.hint, summary == nil {
-                VStack {
-                    HintOverlayView(message: hint.message, recommendations: hint.recommendations)
-                    Spacer()
-                }
-                .padding(.top, 24)
-                .transition(.opacity)
-            }
 
             if let summary {
                 WinOverlayView(summary: summary, onPlayAgain: { viewModel.startNewGame() })
                     .padding(.horizontal, 32)
                     .transition(.opacity.combined(with: .scale))
             }
+        }
+        .overlay(alignment: .topTrailing) {
+            ZoomControlView(zoomLevel: $zoomScale)
+                .padding(.top, 16)
+                .padding(.trailing, 24)
         }
         .animation(.spring(response: 0.45, dampingFraction: 0.85), value: summary != nil)
     }
@@ -74,6 +74,12 @@ struct ContentView: View {
                 currentPlayerIndex: viewModel.state.currentPlayerIndex,
                 turn: viewModel.state.turn
             )
+
+            if let hint = viewModel.hint, viewModel.gameSummary == nil {
+                HintOverlayView(message: hint.message, recommendations: hint.recommendations)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
             Spacer(minLength: 0)
         }
         .frame(width: 300, alignment: .leading)
@@ -131,9 +137,9 @@ struct ContentView: View {
                     recycleCount: viewModel.state.recyclePile.count
                 )
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     @ViewBuilder

--- a/Sources/SpiteAndMaliceApp/Views/DrawPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/DrawPileView.swift
@@ -6,21 +6,34 @@ struct DrawPileView: View {
     var recycleCount: Int
 
     var body: some View {
-        VStack(spacing: 6) {
-            ZStack {
-                CardPlaceholder(title: "Draw")
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 14)
-                            .strokeBorder(Color.white.opacity(0.25), lineWidth: 1.5)
+        VStack(spacing: 10) {
+            ZStack(alignment: .topTrailing) {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [Color(red: 0.28, green: 0.33, blue: 0.5), Color(red: 0.19, green: 0.22, blue: 0.36)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
                     )
-                if drawCount > 0 {
-                    Text("\(drawCount)")
-                        .font(.system(size: 20, weight: .bold, design: .rounded))
-                        .foregroundColor(.white)
-                } else {
-                    Text("Reshuffle")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundColor(.white.opacity(0.8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .stroke(Color.white.opacity(0.28), lineWidth: 1.4)
+                    )
+                    .frame(width: 70, height: 98)
+
+                Text("\(drawCount)")
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+
+                if recycleCount > 0 {
+                    PileBadge {
+                        Label("\(recycleCount)", systemImage: "arrow.triangle.2.circlepath")
+                            .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                            .labelStyle(.titleAndIcon)
+                            .imageScale(.small)
+                    }
+                    .offset(x: -6, y: 8)
                 }
             }
         }

--- a/Sources/SpiteAndMaliceApp/Views/HintOverlayView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HintOverlayView.swift
@@ -6,59 +6,78 @@ struct HintOverlayView: View {
     var recommendations: [GameViewModel.Hint.Recommendation]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
                 Image(systemName: "lightbulb.fill")
-                    .font(.system(size: 14, weight: .bold))
-                Text("Tip")
-                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundColor(Color.yellow.opacity(0.9))
+                    .padding(10)
+                    .background(Circle().fill(Color.yellow.opacity(0.18)))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Helpful tip")
+                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                        .foregroundColor(.white.opacity(0.92))
+                    Text("Tap Hint again to dismiss")
+                        .font(.system(size: 11.5, weight: .medium, design: .rounded))
+                        .foregroundColor(.white.opacity(0.6))
+                }
             }
-            .foregroundColor(.black.opacity(0.85))
 
-            Text(message)
-                .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .foregroundColor(.black.opacity(0.92))
-                .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: 10) {
+                Text(message)
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.9))
+                    .fixedSize(horizontal: false, vertical: true)
 
-            if !recommendations.isEmpty {
-                Divider()
-                    .background(Color.black.opacity(0.15))
+                if !recommendations.isEmpty {
+                    Divider()
+                        .overlay(Color.white.opacity(0.12))
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Top plays")
-                        .font(.system(size: 12.5, weight: .bold, design: .rounded))
-                        .foregroundColor(.black.opacity(0.7))
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("Recommended plays")
+                            .font(.system(size: 12.5, weight: .bold, design: .rounded))
+                            .foregroundColor(.white.opacity(0.68))
 
-                    ForEach(recommendations, id: \.rank) { recommendation in
-                        HStack(alignment: .top, spacing: 10) {
-                            Text("\(recommendation.rank)")
-                                .font(.system(size: 13, weight: .bold, design: .rounded))
-                                .padding(6)
-                                .background(Circle().fill(Color.black.opacity(0.08)))
-                                .foregroundColor(.black.opacity(0.75))
+                        ForEach(recommendations, id: \.rank) { recommendation in
+                            HStack(alignment: .top, spacing: 12) {
+                                Text("\(recommendation.rank)")
+                                    .font(.system(size: 12.5, weight: .bold, design: .rounded))
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 6)
+                                    .background(
+                                        Capsule(style: .continuous)
+                                            .fill(Color.yellow.opacity(0.2))
+                                    )
+                                    .foregroundColor(Color.yellow.opacity(0.9))
 
-                            Text(recommendation.detail)
-                                .font(.system(size: 12.5, weight: .semibold, design: .rounded))
-                                .foregroundColor(.black.opacity(0.78))
-                                .fixedSize(horizontal: false, vertical: true)
+                                Text(recommendation.detail)
+                                    .font(.system(size: 12.5, weight: .semibold, design: .rounded))
+                                    .foregroundColor(.white.opacity(0.82))
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
                         }
                     }
                 }
             }
-
-            Text("Tap the Hint button again to dismiss.")
-                .font(.system(size: 11.5, weight: .medium, design: .rounded))
-                .foregroundColor(.black.opacity(0.6))
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 16)
+        .padding(.horizontal, 22)
+        .padding(.vertical, 20)
         .background(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color.yellow.opacity(0.9))
-                .shadow(color: Color.black.opacity(0.25), radius: 10, x: 0, y: 4)
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [Color(red: 0.22, green: 0.28, blue: 0.48).opacity(0.95), Color(red: 0.15, green: 0.18, blue: 0.32).opacity(0.92)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
         )
-        .padding(.top, 8)
-        .transition(.opacity.combined(with: .scale))
+        .overlay(
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .stroke(Color.white.opacity(0.18), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.28), radius: 14, y: 6)
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
@@ -21,7 +21,7 @@ struct HumanPlayerAreaView: View {
         VStack(spacing: 20) {
             PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            HStack(alignment: .top, spacing: 22) {
+            HStack(alignment: .top, spacing: 26) {
                 StockPileView(
                     cards: player.stockPile,
                     isFaceDown: false,
@@ -41,7 +41,7 @@ struct HumanPlayerAreaView: View {
                     }
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
 
             HandView(
                 cards: player.hand,
@@ -56,7 +56,7 @@ struct HumanPlayerAreaView: View {
             RoundedRectangle(cornerRadius: 20)
                 .fill(Color.white.opacity(0.08))
         )
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 }
 

--- a/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
@@ -10,7 +10,7 @@ struct OpponentAreaView: View {
         VStack(spacing: 18) {
             PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            HStack(spacing: 22) {
+            HStack(alignment: .top, spacing: 26) {
                 StockPileView(
                     cards: player.stockPile,
                     isFaceDown: false,
@@ -31,7 +31,7 @@ struct OpponentAreaView: View {
                     }
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(.vertical, 20)
         .padding(.horizontal, 22)
@@ -39,7 +39,7 @@ struct OpponentAreaView: View {
             RoundedRectangle(cornerRadius: 20)
                 .fill(Color.white.opacity(0.05))
         )
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/PeekingCardStack.swift
+++ b/Sources/SpiteAndMaliceApp/Views/PeekingCardStack.swift
@@ -3,8 +3,9 @@ import SwiftUI
 import SpiteAndMaliceCore
 
 struct PeekingCardStack: View {
-    static let defaultPeekHeight: CGFloat = 14
-    static let defaultMaxPeekCount: Int = 3
+    static let defaultPeekHeight: CGFloat = 32
+    static let defaultPeekSpacing: CGFloat = 18
+    static let defaultMaxPeekCount: Int = 4
 
     var cards: [Card]
     var isFaceDown: Bool
@@ -15,19 +16,31 @@ struct PeekingCardStack: View {
     }
 
     var body: some View {
-        ZStack(alignment: .top) {
+        let cardHeight = 98 * scale
+
+        return ZStack(alignment: .topLeading) {
             ForEach(Array(visibleCards.enumerated()), id: \.element.id) { index, card in
-                let offsetAmount = CGFloat(visibleCards.count - index) * Self.defaultPeekHeight
+                let isTopCard = index == visibleCards.indices.last
                 CardView(card: card, isFaceDown: isFaceDown, scale: scale)
-                    .opacity(0.55 + (Double(index) * 0.12))
-                    .offset(y: -offsetAmount)
+                    .mask(
+                        VStack(spacing: 0) {
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .frame(height: isTopCard ? cardHeight : Self.defaultPeekHeight)
+                            Spacer(minLength: 0)
+                        }
+                    )
+                    .offset(y: CGFloat(index) * Self.defaultPeekSpacing)
+                    .shadow(color: Color.black.opacity(isTopCard ? 0.3 : 0.18), radius: isTopCard ? 8 : 4, y: isTopCard ? 6 : 3)
+                    .zIndex(Double(index))
             }
         }
+        .frame(height: cardHeight + CGFloat(max(visibleCards.count - 1, 0)) * Self.defaultPeekSpacing, alignment: .top)
+        .clipped()
         .allowsHitTesting(false)
     }
 
     static func padding(forCardCount count: Int) -> CGFloat {
-        CGFloat(min(count, defaultMaxPeekCount)) * defaultPeekHeight
+        CGFloat(min(count, defaultMaxPeekCount)) * defaultPeekSpacing
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
@@ -12,15 +12,15 @@ struct StockPileView: View {
     private var topCard: Card? { cards.last }
 
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 12) {
             ZStack {
                 stockContent
                     .accessibilityLabel(Text(accessibilityLabel))
             }
-            .overlay(alignment: .leading) {
+            .overlay(alignment: .topTrailing) {
                 countIndicator
                     .allowsHitTesting(false)
-                    .offset(x: -72)
+                    .padding(8)
             }
 
             Text("Stock")
@@ -74,35 +74,31 @@ struct StockPileView: View {
     }
 
     private var countIndicator: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: 6) {
             Image(systemName: "rectangle.stack.fill")
-                .font(.system(size: 16, weight: .semibold))
+                .font(.system(size: 14, weight: .semibold))
             Text("\(remainingCount)")
                 .font(.system(size: 16, weight: .bold, design: .rounded))
-            Text("Left")
-                .font(.system(size: 10, weight: .medium, design: .rounded))
-                .opacity(0.8)
         }
         .foregroundStyle(Color.white)
         .padding(.horizontal, 12)
-        .padding(.vertical, 12)
+        .padding(.vertical, 10)
         .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(
                     LinearGradient(
-                        colors: [Color.white.opacity(0.26), Color.white.opacity(0.1)],
+                        colors: [Color.white.opacity(0.28), Color.white.opacity(0.12)],
                         startPoint: .topLeading,
                         endPoint: .bottomTrailing
                     )
                 )
-                .opacity(0.95)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(Color.white.opacity(0.35), lineWidth: 0.9)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.32), lineWidth: 0.9)
         )
-        .shadow(color: Color.black.opacity(0.35), radius: 8, y: 4)
-        .frame(minWidth: 68)
+        .shadow(color: Color.black.opacity(0.3), radius: 6, y: 3)
+        .frame(minWidth: 62)
         .opacity(remainingCount == 0 ? 0.65 : 1)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text("Stock cards remaining: \(remainingCount)"))

--- a/Sources/SpiteAndMaliceApp/Views/ZoomControlView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ZoomControlView.swift
@@ -1,0 +1,39 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct ZoomControlView: View {
+    @Binding var zoomLevel: CGFloat
+
+    private let range: ClosedRange<CGFloat> = 0.8...1.4
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 8) {
+            HStack(spacing: 10) {
+                Image(systemName: "minus.magnifyingglass")
+                    .foregroundColor(.white.opacity(0.85))
+                Slider(value: $zoomLevel, in: range)
+                    .tint(Color.white)
+                Image(systemName: "plus.magnifyingglass")
+                    .foregroundColor(.white.opacity(0.85))
+            }
+            .frame(width: 220)
+
+            Text("\(Int(zoomLevel * 100))%")
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.85))
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .opacity(0.92)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.white.opacity(0.28), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.3), radius: 12, y: 6)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add an overlay zoom slider that scales the entire play surface and keep the main layout centered
- move the hint/tips panel beneath the scoreboard with a refreshed card-style presentation
- tighten player and build pile alignment while updating stock/draw stacks to show clearer peeking cards and counters

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ca5f80969c83299059d5b2dc35a8c4