### PR TITLE
Refine card stacking presentation

### DIFF
--- a/Sources/SpiteAndMaliceApp/Views/BuildPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/BuildPileView.swift
@@ -33,9 +33,9 @@ struct BuildPileView: View {
                     )
                 }
                 interactiveCard(for: top)
-                    .offset(y: PeekingCardStack.topCardOffset(forTotalCount: cardCount))
+                    .offset(y: PeekingCardStack.topCardOffset(forTotalCount: cardCount, scale: 0.94))
             }
-            .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: cardCount, topScale: 1))
+            .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: cardCount, topScale: 1, peekScale: 0.94))
         } else {
             placeholderCard
         }

--- a/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
@@ -33,12 +33,12 @@ struct DiscardPileView: View {
 
             if let card = cards.last {
                 interactiveTopCard(card: card)
-                    .offset(y: PeekingCardStack.topCardOffset(forTotalCount: cards.count))
+                    .offset(y: PeekingCardStack.topCardOffset(forTotalCount: cards.count, scale: 0.92))
             } else {
                 placeholderCard
             }
         }
-        .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: cards.count, topScale: 0.95))
+        .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: cards.count, topScale: 0.95, peekScale: 0.92))
     }
 
     @ViewBuilder

--- a/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
@@ -17,7 +17,7 @@ struct StockPileView: View {
                 stockContent
                     .accessibilityLabel(Text(accessibilityLabel))
             }
-            .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: remainingCount, topScale: 1))
+            .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: remainingCount, topScale: 1, peekScale: 0.98))
             .overlay(alignment: .topTrailing) {
                 countIndicator
                     .allowsHitTesting(false)
@@ -42,7 +42,7 @@ struct StockPileView: View {
             }
 
             interactiveCard(for: card)
-                .offset(y: PeekingCardStack.topCardOffset(forTotalCount: remainingCount))
+                .offset(y: PeekingCardStack.topCardOffset(forTotalCount: remainingCount, scale: 0.98))
         } else {
             placeholderCard
                 .frame(height: 98)


### PR DESCRIPTION
## Summary
- cascade stacked cards with larger spacing, depth-aware scaling, and shadows so underlying cards remain visible
- update pile views to adopt the new stack metrics for consistent alignment across stock, build, and discard piles

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cb9a01826c8329a9ba85f9aa5928b5