### PR TITLE
Refine pile displays and hand context

### DIFF
--- a/Sources/SpiteAndMaliceApp/Views/BuildPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/BuildPileView.swift
@@ -33,9 +33,9 @@ struct BuildPileView: View {
                     )
                 }
                 interactiveCard(for: top)
-                    .offset(y: PeekingCardStack.topCardOffset(forTotalCount: cardCount))
+                    .offset(y: PeekingCardStack.topCardOffset(forTotalCount: cardCount, scale: 0.94))
             }
-            .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: cardCount, topScale: 1))
+            .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: cardCount, topScale: 1, peekScale: 0.94))
         } else {
             placeholderCard
         }

--- a/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
@@ -7,6 +7,7 @@ struct DiscardPileView: View {
     var title: String
     var isHighlighted: Bool = false
     var isInteractive: Bool = false
+    var showsStackWhenMultiple: Bool = true
     var action: (() -> Void)?
 
     var body: some View {
@@ -23,22 +24,9 @@ struct DiscardPileView: View {
     @ViewBuilder
     private var discardContent: some View {
         ZStack(alignment: .topLeading) {
-            if cards.count > 1 {
-                PeekingCardStack(
-                    cards: Array(cards.dropLast()),
-                    isFaceDown: false,
-                    scale: 0.92
-                )
-            }
-
-            if let card = cards.last {
-                interactiveTopCard(card: card)
-                    .offset(y: PeekingCardStack.topCardOffset(forTotalCount: cards.count))
-            } else {
-                placeholderCard
-            }
+            discardStack
         }
-        .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: cards.count, topScale: 0.95))
+        .frame(height: stackHeight)
     }
 
     @ViewBuilder
@@ -67,6 +55,36 @@ struct DiscardPileView: View {
             CardPlaceholder(title: "Discard")
                 .scaleEffect(0.95)
                 .opacity(isInteractive ? 1 : 0.65)
+        }
+    }
+
+    @ViewBuilder
+    private var discardStack: some View {
+        if let card = cards.last {
+            if showsStackWhenMultiple, cards.count > 1 {
+                let underlying = Array(cards.dropLast())
+                PeekingCardStack(
+                    cards: underlying,
+                    isFaceDown: false,
+                    scale: 0.92
+                )
+
+                interactiveTopCard(card: card)
+                    .offset(y: PeekingCardStack.topCardOffset(forTotalCount: cards.count, scale: 0.92))
+            } else {
+                interactiveTopCard(card: card)
+            }
+        } else {
+            placeholderCard
+        }
+    }
+
+    private var stackHeight: CGFloat {
+        guard let _ = cards.last else { return 98 * 0.95 }
+        if showsStackWhenMultiple, cards.count > 1 {
+            return PeekingCardStack.totalStackHeight(forTotalCount: cards.count, topScale: 0.95, peekScale: 0.92)
+        } else {
+            return 98 * 0.95
         }
     }
 }

--- a/Sources/SpiteAndMaliceApp/Views/DrawPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/DrawPileView.swift
@@ -7,7 +7,7 @@ struct DrawPileView: View {
 
     var body: some View {
         VStack(spacing: 10) {
-            ZStack(alignment: .topTrailing) {
+            ZStack {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(
                         LinearGradient(
@@ -23,9 +23,10 @@ struct DrawPileView: View {
                     .frame(width: 70, height: 98)
 
                 Text("\(drawCount)")
-                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
                     .foregroundColor(.white)
-
+            }
+            .overlay(alignment: .topTrailing) {
                 if recycleCount > 0 {
                     PileBadge {
                         Label("\(recycleCount)", systemImage: "arrow.triangle.2.circlepath")

--- a/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
@@ -36,6 +36,7 @@ struct HumanPlayerAreaView: View {
                             title: "Discard",
                             isHighlighted: selectedDiscardIndex == index,
                             isInteractive: true,
+                            showsStackWhenMultiple: false,
                             action: { onTapDiscard(index) }
                         )
                     }
@@ -43,12 +44,19 @@ struct HumanPlayerAreaView: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
 
-            HandView(
-                cards: player.hand,
-                selectedCardID: selection?.card.id,
-                tapAction: onSelectHandCard
-            )
-            .frame(maxWidth: .infinity, alignment: .center)
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Your Hand")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.85))
+
+                HandView(
+                    cards: player.hand,
+                    selectedCardID: selection?.card.id,
+                    tapAction: onSelectHandCard
+                )
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 22)
         .padding(.horizontal, 24)

--- a/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
@@ -32,6 +32,16 @@ struct OpponentAreaView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("\(player.name)'s Hand")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.78))
+
+                OpponentHandSummaryView(count: player.hand.count)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 20)
         .padding(.horizontal, 22)
@@ -40,6 +50,39 @@ struct OpponentAreaView: View {
                 .fill(Color.white.opacity(0.05))
         )
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+private struct OpponentHandSummaryView: View {
+    var count: Int
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [Color(red: 0.23, green: 0.27, blue: 0.39), Color(red: 0.15, green: 0.18, blue: 0.28)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(Color.white.opacity(0.25), lineWidth: 1.2)
+                )
+                .frame(width: 70, height: 98)
+
+            VStack(spacing: 4) {
+                Text("\(count)")
+                    .font(.system(size: 26, weight: .heavy, design: .rounded))
+                    .foregroundColor(.white)
+                Text(count == 1 ? "card" : "cards")
+                    .font(.system(size: 12, weight: .medium, design: .rounded))
+                    .foregroundColor(.white.opacity(0.8))
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Opponent hand has \(count) cards"))
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/PeekingCardStack.swift
+++ b/Sources/SpiteAndMaliceApp/Views/PeekingCardStack.swift
@@ -3,60 +3,96 @@ import SwiftUI
 import SpiteAndMaliceCore
 
 struct PeekingCardStack: View {
-    static let defaultPeekHeight: CGFloat = 36
-    static let defaultPeekSpacing: CGFloat = 18
+    static let defaultPeekSpacing: CGFloat = 26
     static let defaultMaxPeekCount: Int = 5
+    static let depthScaleStep: CGFloat = 0.04
 
     var cards: [Card]
     var isFaceDown: Bool
     var scale: CGFloat
-    var showsFullTopCard: Bool = false
 
     private var visibleCards: [Card] {
         Array(cards.suffix(Self.defaultMaxPeekCount))
     }
 
     var body: some View {
-        let cardHeight = 98 * scale
-
-        return ZStack(alignment: .topLeading) {
+        ZStack(alignment: .topLeading) {
             ForEach(Array(visibleCards.enumerated()), id: \.element.id) { index, card in
-                let isTopCard = index == visibleCards.indices.last
-                let drawsFullCard = showsFullTopCard && isTopCard
-                CardView(card: card, isFaceDown: isFaceDown, scale: scale)
-                    .mask(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .frame(height: drawsFullCard ? cardHeight : Self.defaultPeekHeight)
-                    )
-                    .offset(y: CGFloat(index) * Self.defaultPeekSpacing)
-                    .shadow(color: Color.black.opacity(drawsFullCard ? 0.28 : 0.16), radius: drawsFullCard ? 8 : 4, y: drawsFullCard ? 6 : 3)
+                let total = visibleCards.count
+                let cardScale = cardScale(forIndex: index, totalCount: total)
+                CardView(card: card, isFaceDown: isFaceDown, scale: cardScale)
+                    .overlay(alignment: .top) {
+                        if !isFaceDown {
+                            peekLabel(for: card, scale: cardScale)
+                        }
+                    }
+                    .offset(y: offset(forIndex: index))
+                    .shadow(color: Color.black.opacity(shadowOpacity(forIndex: index, totalCount: total)), radius: 6, y: 4)
                     .zIndex(Double(index))
             }
         }
         .frame(
-            width: 70 * scale,
-            height: Self.stackHeight(forVisibleCount: visibleCards.count, scale: scale, showsFullTopCard: showsFullTopCard),
+            width: stackWidth,
+            height: Self.stackHeight(forVisibleCount: visibleCards.count, scale: scale),
             alignment: .topLeading
         )
         .allowsHitTesting(false)
     }
 
-    static func stackHeight(forVisibleCount visibleCount: Int, scale: CGFloat, showsFullTopCard: Bool) -> CGFloat {
+    private var stackWidth: CGFloat { 70 * scale }
+
+    private func offset(forIndex index: Int) -> CGFloat {
+        CGFloat(index) * Self.spacing(for: scale)
+    }
+
+    private func cardScale(forIndex index: Int, totalCount: Int) -> CGFloat {
+        guard totalCount > 1 else { return scale }
+        let depth = totalCount - index - 1
+        let multiplier = max(0.82, 1 - (CGFloat(depth) * Self.depthScaleStep))
+        return scale * multiplier
+    }
+
+    private func shadowOpacity(forIndex index: Int, totalCount: Int) -> Double {
+        guard totalCount > 1 else { return 0.2 }
+        let depth = totalCount - index - 1
+        return Double(0.18 + (CGFloat(depth) * 0.05))
+    }
+
+    private func peekLabel(for card: Card, scale: CGFloat) -> some View {
+        Text(card.displayName)
+            .font(.system(size: 14 * scale, weight: .heavy, design: .rounded))
+            .foregroundColor(.white)
+            .padding(.horizontal, 6 * scale)
+            .padding(.vertical, 2.5 * scale)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(Color.black.opacity(0.55))
+            )
+            .padding(.top, 6 * scale)
+            .opacity(0.95)
+    }
+
+    private static func spacing(for scale: CGFloat) -> CGFloat {
+        defaultPeekSpacing * max(scale, 0.82)
+    }
+
+    static func stackHeight(forVisibleCount visibleCount: Int, scale: CGFloat) -> CGFloat {
         guard visibleCount > 0 else { return 0 }
-        let cardHeight = 98 * scale
-        let overlaps = max(visibleCount - 1, 0)
-        let topHeight = showsFullTopCard ? cardHeight : defaultPeekHeight
-        return topHeight + CGFloat(overlaps) * defaultPeekSpacing
+        let spacing = Self.spacing(for: scale)
+        let lastOffset = CGFloat(visibleCount - 1) * spacing
+        let lastCardHeight = 98 * scale
+        return lastOffset + lastCardHeight
     }
 
-    static func topCardOffset(forTotalCount totalCount: Int) -> CGFloat {
-        CGFloat(min(max(totalCount - 1, 0), defaultMaxPeekCount)) * defaultPeekSpacing
-    }
-
-    static func totalStackHeight(forTotalCount totalCount: Int, topScale: CGFloat) -> CGFloat {
-        guard totalCount > 0 else { return 98 * topScale }
+    static func topCardOffset(forTotalCount totalCount: Int, scale: CGFloat) -> CGFloat {
+        guard totalCount > 0 else { return 0 }
         let visible = min(max(totalCount - 1, 0), defaultMaxPeekCount)
-        return (98 * topScale) + CGFloat(visible) * defaultPeekSpacing
+        return CGFloat(visible) * Self.spacing(for: scale)
+    }
+
+    static func totalStackHeight(forTotalCount totalCount: Int, topScale: CGFloat, peekScale: CGFloat) -> CGFloat {
+        guard totalCount > 0 else { return 98 * topScale }
+        return (98 * topScale) + topCardOffset(forTotalCount: totalCount, scale: peekScale)
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/StockPileView.swift
@@ -12,17 +12,15 @@ struct StockPileView: View {
     private var topCard: Card? { cards.last }
 
     var body: some View {
-        VStack(spacing: 12) {
-            ZStack(alignment: .topLeading) {
+        VStack(spacing: 14) {
+            HStack(alignment: .center, spacing: 14) {
+                countIndicator
+                    .accessibilityHidden(true)
+
                 stockContent
                     .accessibilityLabel(Text(accessibilityLabel))
             }
-            .frame(height: PeekingCardStack.totalStackHeight(forTotalCount: remainingCount, topScale: 1))
-            .overlay(alignment: .topTrailing) {
-                countIndicator
-                    .allowsHitTesting(false)
-                    .padding(8)
-            }
+            .frame(maxWidth: .infinity, alignment: .center)
 
             Text("Stock")
                 .font(.system(size: 13, weight: .semibold, design: .rounded))
@@ -33,16 +31,8 @@ struct StockPileView: View {
     @ViewBuilder
     private var stockContent: some View {
         if let card = topCard {
-            if remainingCount > 1 {
-                PeekingCardStack(
-                    cards: Array(cards.dropLast()),
-                    isFaceDown: true,
-                    scale: 0.98
-                )
-            }
-
             interactiveCard(for: card)
-                .offset(y: PeekingCardStack.topCardOffset(forTotalCount: remainingCount))
+                .frame(height: 98)
         } else {
             placeholderCard
                 .frame(height: 98)
@@ -75,32 +65,31 @@ struct StockPileView: View {
     }
 
     private var countIndicator: some View {
-        VStack(spacing: 6) {
-            Image(systemName: "rectangle.stack.fill")
-                .font(.system(size: 14, weight: .semibold))
+        VStack(spacing: 4) {
+            Text("Remaining")
+                .font(.system(size: 11, weight: .medium, design: .rounded))
             Text("\(remainingCount)")
-                .font(.system(size: 16, weight: .bold, design: .rounded))
+                .font(.system(size: 20, weight: .heavy, design: .rounded))
         }
-        .foregroundStyle(Color.white)
+        .foregroundColor(.white)
         .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.vertical, 14)
         .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(
                     LinearGradient(
-                        colors: [Color.white.opacity(0.28), Color.white.opacity(0.12)],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
+                        colors: [Color.white.opacity(0.18), Color.white.opacity(0.08)],
+                        startPoint: .top,
+                        endPoint: .bottom
                     )
                 )
         )
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(Color.white.opacity(0.32), lineWidth: 0.9)
+                .stroke(Color.white.opacity(0.28), lineWidth: 1)
         )
-        .shadow(color: Color.black.opacity(0.3), radius: 6, y: 3)
-        .frame(minWidth: 62)
-        .opacity(remainingCount == 0 ? 0.65 : 1)
+        .shadow(color: Color.black.opacity(0.35), radius: 8, y: 6)
+        .opacity(remainingCount == 0 ? 0.6 : 1)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text("Stock cards remaining: \(remainingCount)"))
     }


### PR DESCRIPTION
## Summary
- present the stock pile as a single actionable card with a flanking count badge instead of a stacked fan
- update discard piles to optionally fan cards and add labeled peeks while keeping the active player's piles flat
- add explicit hand labels for the human player, show opponent hand counts, and center the draw pile counter

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cb9a01826c8329a9ba85f9aa5928b5