### PR TITLE
Improve layout responsiveness for card table

### DIFF
--- a/Sources/SpiteAndMaliceApp/Views/ContentView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ContentView.swift
@@ -27,17 +27,15 @@ struct ContentView: View {
     }
 
     private var mainContent: some View {
-        VStack(alignment: .leading, spacing: 32) {
+        VStack(alignment: .leading, spacing: 24) {
             header
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            HStack(alignment: .top, spacing: 32) {
+            HStack(alignment: .top, spacing: 24) {
                 activityColumn
 
-                VStack(spacing: 28) {
-                    opponentsSection
-                    centrePlayArea
-                    humanSection
+                VStack(spacing: 20) {
+                    cardTable
                     controlSection
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -45,9 +43,9 @@ struct ContentView: View {
                 sidebarColumn
             }
         }
-        .padding(.vertical, 48)
-        .padding(.horizontal, 32)
-        .frame(maxWidth: 1360)
+        .padding(.vertical, 36)
+        .padding(.horizontal, 24)
+        .frame(maxWidth: 1200)
         .frame(maxWidth: .infinity, alignment: .top)
     }
 
@@ -56,7 +54,7 @@ struct ContentView: View {
             RecentActivityView(events: viewModel.activityLog())
             Spacer(minLength: 0)
         }
-        .frame(width: 260, alignment: .leading)
+        .frame(width: 228, alignment: .leading)
     }
 
     private var sidebarColumn: some View {
@@ -74,7 +72,7 @@ struct ContentView: View {
 
             Spacer(minLength: 0)
         }
-        .frame(width: 280, alignment: .leading)
+        .frame(width: 244, alignment: .leading)
     }
 
     private var backgroundView: some View {
@@ -98,21 +96,51 @@ struct ContentView: View {
         }
     }
 
+    private var cardTable: some View {
+        let hasOpponents = viewModel.state.players.contains(where: { !$0.isHuman })
+        let hasHumanPlayer = viewModel.state.players.contains(where: { $0.isHuman })
+
+        return VStack(spacing: 20) {
+            if hasOpponents {
+                opponentsSection
+            }
+
+            if hasOpponents {
+                tableDivider
+            }
+
+            sharedStacksSection
+
+            if hasHumanPlayer {
+                tableDivider
+                humanSection
+            }
+        }
+        .padding(.vertical, 24)
+        .padding(.horizontal, 26)
+        .background(
+            RoundedRectangle(cornerRadius: 28)
+                .fill(Color.white.opacity(0.06))
+        )
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
     private var opponentsSection: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: 16) {
             ForEach(Array(viewModel.state.players.enumerated()).filter { !$0.element.isHuman }, id: \.element.id) { item in
                 OpponentAreaView(
                     player: item.element,
-                    isCurrentTurn: viewModel.state.currentPlayerIndex == item.offset
+                    isCurrentTurn: viewModel.state.currentPlayerIndex == item.offset,
+                    showsContainer: false
                 )
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var centrePlayArea: some View {
-        VStack(spacing: 24) {
-            HStack(alignment: .top, spacing: 28) {
+    private var sharedStacksSection: some View {
+        VStack(spacing: 18) {
+            HStack(alignment: .top, spacing: 24) {
                 ForEach(Array(viewModel.state.buildPiles.enumerated()), id: \.0) { index, pile in
                     BuildPileView(
                         pile: pile,
@@ -133,6 +161,12 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, alignment: .center)
     }
 
+    private var tableDivider: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.12))
+            .frame(height: 1)
+    }
+
     @ViewBuilder
     private var humanSection: some View {
         if let humanIndex = viewModel.state.players.firstIndex(where: { $0.isHuman }) {
@@ -144,7 +178,8 @@ struct ContentView: View {
                 selection: viewModel.selection,
                 onSelectStock: viewModel.selectStockCard,
                 onTapDiscard: { index in viewModel.handleDiscardTap(index) },
-                onSelectHandCard: { index in viewModel.selectHandCard(at: index) }
+                onSelectHandCard: { index in viewModel.selectHandCard(at: index) },
+                showsContainer: false
             )
         }
     }
@@ -159,6 +194,7 @@ struct ContentView: View {
             isUndoDisabled: !viewModel.canUndoTurn
         )
         .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.top, 6)
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/DiscardPileView.swift
@@ -18,6 +18,9 @@ struct DiscardPileView: View {
             Text(title)
                 .font(.system(size: 13, weight: .medium, design: .rounded))
                 .foregroundColor(.white.opacity(0.75))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(minWidth: 64)
         }
         .opacity(isInteractive ? 1 : 0.9)
         .animation(.spring(response: 0.35, dampingFraction: 0.85), value: cards.count)

--- a/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/HumanPlayerAreaView.swift
@@ -10,6 +10,7 @@ struct HumanPlayerAreaView: View {
     var onSelectStock: () -> Void
     var onTapDiscard: (Int) -> Void
     var onSelectHandCard: (Int) -> Void
+    var showsContainer: Bool = true
 
     private var selectedDiscardIndex: Int? {
         guard let selection else { return nil }
@@ -18,10 +19,17 @@ struct HumanPlayerAreaView: View {
     }
 
     var body: some View {
-        VStack(spacing: 20) {
-            PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            HStack(alignment: .top, spacing: 26) {
+        let content = VStack(spacing: 18) {
+            HStack(alignment: .center, spacing: 16) {
+                PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Spacer(minLength: 0)
+
+                HandSummaryLabel(count: player.hand.count)
+            }
+
+            HStack(alignment: .top, spacing: 22) {
                 StockPileView(
                     cards: player.stockPile,
                     isFaceDown: false,
@@ -43,27 +51,28 @@ struct HumanPlayerAreaView: View {
             }
             .frame(maxWidth: .infinity, alignment: .center)
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Your Hand")
-                    .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.85))
-
-                HandView(
-                    cards: player.hand,
-                    selectedCardID: selection?.card.id,
-                    tapAction: onSelectHandCard
-                )
-                .frame(maxWidth: .infinity, alignment: .center)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            HandView(
+                cards: player.hand,
+                selectedCardID: selection?.card.id,
+                tapAction: onSelectHandCard
+            )
+            .frame(maxWidth: .infinity, alignment: .center)
         }
-        .padding(.vertical, 22)
-        .padding(.horizontal, 24)
-        .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.white.opacity(0.08))
-        )
-        .frame(maxWidth: .infinity, alignment: .center)
+
+        Group {
+            if showsContainer {
+                content
+                    .padding(.vertical, 20)
+                    .padding(.horizontal, 22)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color.white.opacity(0.08))
+                    )
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                content
+            }
+        }
     }
 }
 
@@ -71,6 +80,32 @@ private extension CardOrigin {
     var isStock: Bool {
         if case .stock = self { return true }
         return false
+    }
+}
+
+private struct HandSummaryLabel: View {
+    var count: Int
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("Hand")
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundColor(.white.opacity(0.7))
+
+            Text("\(count)")
+                .font(.system(size: 22, weight: .heavy, design: .rounded))
+                .foregroundColor(.white)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.white.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.18), lineWidth: 1)
+        )
     }
 }
 #endif

--- a/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/OpponentAreaView.swift
@@ -5,12 +5,18 @@ import SpiteAndMaliceCore
 struct OpponentAreaView: View {
     var player: Player
     var isCurrentTurn: Bool
+    var showsContainer: Bool = true
 
     var body: some View {
-        VStack(spacing: 18) {
-            PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            HStack(alignment: .top, spacing: 26) {
+        let content = VStack(spacing: 16) {
+            HStack(alignment: .center, spacing: 16) {
+                PlayerHeaderView(player: player, isCurrentTurn: isCurrentTurn)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                OpponentHandSummaryView(count: player.hand.count)
+            }
+
+            HStack(alignment: .top, spacing: 22) {
                 StockPileView(
                     cards: player.stockPile,
                     isFaceDown: false,
@@ -32,24 +38,22 @@ struct OpponentAreaView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .center)
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("\(player.name)'s Hand")
-                    .font(.system(size: 14, weight: .semibold, design: .rounded))
-                    .foregroundColor(.white.opacity(0.78))
-
-                OpponentHandSummaryView(count: player.hand.count)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.vertical, 20)
-        .padding(.horizontal, 22)
-        .background(
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color.white.opacity(0.05))
-        )
-        .frame(maxWidth: .infinity, alignment: .center)
+
+        Group {
+            if showsContainer {
+                content
+                    .padding(.vertical, 18)
+                    .padding(.horizontal, 22)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color.white.opacity(0.05))
+                    )
+                    .frame(maxWidth: .infinity, alignment: .center)
+            } else {
+                content
+            }
+        }
     }
 }
 
@@ -70,7 +74,7 @@ private struct OpponentHandSummaryView: View {
                     RoundedRectangle(cornerRadius: 14, style: .continuous)
                         .stroke(Color.white.opacity(0.25), lineWidth: 1.2)
                 )
-                .frame(width: 70, height: 98)
+                .frame(width: 64, height: 94)
 
             VStack(spacing: 4) {
                 Text("\(count)")


### PR DESCRIPTION
## Summary
- tighten the main layout so the activity and sidebar columns take less width and the central card table sits inside a unified surface that adapts to opponents and the human player
- rework the human and opponent areas to share a compact header layout with inline hand counters and optional background containers for embedding inside the new table
- prevent discard pile captions from wrapping by constraining their width

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68cbb141c2e883299955597b85f589f2