### PR TITLE
Prevent hint auto-selection and align side panels

### DIFF
--- a/Sources/SpiteAndMaliceApp/ViewModels/GameViewModel.swift
+++ b/Sources/SpiteAndMaliceApp/ViewModels/GameViewModel.swift
@@ -358,9 +358,8 @@ final class GameViewModel: ObservableObject {
             return
         }
 
-        if let payload = hintPayload(for: humanIndex) {
-            hint = payload.hint
-            selection = payload.selection
+        if let updatedHint = hintPayload(for: humanIndex) {
+            hint = updatedHint
         } else {
             hint = Hint(
                 message: "No plays available right now. Discard to set up your next turn.",
@@ -368,11 +367,10 @@ final class GameViewModel: ObservableObject {
                 suggestedPileIndex: nil,
                 recommendations: []
             )
-            selection = nil
         }
     }
 
-    private func hintPayload(for playerIndex: Int) -> (hint: Hint, selection: CardSelection?)? {
+    private func hintPayload(for playerIndex: Int) -> Hint? {
         let rankedPlays = scoredPlayOptions(forPlayerAt: playerIndex)
 
         if let bestPlay = rankedPlays.first {
@@ -382,28 +380,21 @@ final class GameViewModel: ObservableObject {
                     detail: recommendationDescription(for: option)
                 )
             })
-            let hint = Hint(
+            return Hint(
                 message: playMessage(for: bestPlay),
                 suggestedOrigin: bestPlay.origin,
                 suggestedPileIndex: bestPlay.pileIndex,
                 recommendations: recommendations
             )
-            let selection = CardSelection(origin: bestPlay.origin, card: bestPlay.card)
-            return (hint, selection)
         }
 
         if let discardSuggestion = bestDiscard(forPlayerAt: playerIndex) {
-            let hint = Hint(
+            return Hint(
                 message: "No plays available. Discard \(discardSuggestion.card.displayName) to \(discardPileDescription(for: discardSuggestion.discardIndex)).",
                 suggestedOrigin: .hand(playerIndex: playerIndex, handIndex: discardSuggestion.handIndex),
                 suggestedPileIndex: nil,
                 recommendations: []
             )
-            let selection = CardSelection(
-                origin: .hand(playerIndex: playerIndex, handIndex: discardSuggestion.handIndex),
-                card: discardSuggestion.card
-            )
-            return (hint, selection)
         }
 
         return nil

--- a/Sources/SpiteAndMaliceApp/Views/ContentView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ContentView.swift
@@ -72,7 +72,7 @@ struct ContentView: View {
 
             Spacer(minLength: 0)
         }
-        .frame(width: 244, alignment: .leading)
+        .frame(width: 280, alignment: .leading)
     }
 
     private var backgroundView: some View {
@@ -194,6 +194,7 @@ struct ContentView: View {
             isHintPinned: viewModel.isHintPinned,
             isUndoDisabled: !viewModel.canUndoTurn
         )
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 18)
         .padding(.horizontal, 20)
         .background(

--- a/Sources/SpiteAndMaliceApp/Views/RecentActivityView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/RecentActivityView.swift
@@ -29,7 +29,7 @@ struct RecentActivityView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("Recent activity")
+                Text("Recent Activity")
                     .font(.system(size: 16, weight: .semibold, design: .rounded))
                     .foregroundColor(.white.opacity(0.94))
 

--- a/Sources/SpiteAndMaliceApp/Views/ScoreboardView.swift
+++ b/Sources/SpiteAndMaliceApp/Views/ScoreboardView.swift
@@ -80,6 +80,8 @@ private struct ScoreboardPlayerCard: View {
                     .background(
                         Capsule().fill(player.isHuman ? Color.blue.opacity(0.45) : Color.purple.opacity(0.4))
                     )
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
                 Spacer()
                 if isCurrent {
                     Label("Active", systemImage: "flame.fill")


### PR DESCRIPTION
## Summary
- stop pinned hints from automatically selecting cards by leaving selection solely to player input
- widen the controls panel and sidebar column so the side panels mirror the spacing of the title and activity sections
- keep the scoreboard "You" badges on one line and capitalize the Recent Activity heading

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68cc5d86fd148329ae2d98f223aa8132